### PR TITLE
Adds a note to the readme around default hash helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ember install ember-ref-modifier
 ```
 
 ```hbs
-// hash helper must return an EmberObject!
+// hash helper must return an EmberObject! The default hash helper returns a pojo.
 {{#let (hash) as |ctx|}}
 	<input id="name-input" {{ref ctx 'inputNode'}}>
 	<label for={{ctx.inputNode.id}}> Enter your name </label>

--- a/tests/integration/modifiers/ref-test.js
+++ b/tests/integration/modifiers/ref-test.js
@@ -105,17 +105,4 @@ module('Integration | Modifier | ref', function(hooks) {
 
     assert.equal(this.btn.tagName, 'BUTTON');
   });
-
-  test('it works when using the let helper', async function(assert) {
-    assert.expect(1);
-
-    await render(hbs`
-      {{#let (hash) as |ctx|}}
-        <div {{ref ctx 'firstDiv'}} id='first-div'></div>
-        <div id='second-div'>{{ctx.firstDiv.id}}</div>
-      {{/let}}
-    `);
-
-    assert.dom('#second-div').hasText(find('#first-div').id);
-  });
 });

--- a/tests/integration/modifiers/ref-test.js
+++ b/tests/integration/modifiers/ref-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | ref', function(hooks) {

--- a/tests/integration/modifiers/ref-test.js
+++ b/tests/integration/modifiers/ref-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | ref', function(hooks) {
@@ -104,5 +104,18 @@ module('Integration | Modifier | ref', function(hooks) {
     this.set('ctx', this);
 
     assert.equal(this.btn.tagName, 'BUTTON');
+  });
+
+  test('it works when using the let helper', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      {{#let (hash) as |ctx|}}
+        <div {{ref ctx 'firstDiv'}} id='first-div'></div>
+        <div id='second-div'>{{ctx.firstDiv.id}}</div>
+      {{/let}}
+    `);
+
+    assert.dom('#second-div').hasText(find('#first-div').id);
   });
 });


### PR DESCRIPTION
I figure this might be helpful to people since copy/pasting the examples directly will not work.