### PR TITLE
Drop ember-lts-3.12 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: 'Additional Tests'
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
+      env: EMBER_TRY_SCENARIO=ember-3.13
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -48,6 +48,22 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-lts-3.12',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.12.0'
+            }
+          }
+        },
+        {
+          name: 'ember-3.13',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.13.0'
+            }
+          }
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
Added the scenario for ember-try and fixed the extra YAML dash that was
running a bonus tests with no EMBER_TRY_SCENARIO env.

Refs #197 