### PR TITLE
Specify Ember 3.13 as the minimum support version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ember install ember-ref-modifier
 
 #### Compatibility
 
-- Ember.js v2.18 or above
+- Ember.js v3.13 or above
 - ember-cli v2.13 or above
 
 ## Usage


### PR DESCRIPTION
This is the oldest LTS being tested.

Refs #197 