### PR TITLE
Remove deprecated legacy syntax

### DIFF
--- a/addon/modifiers/ref.js
+++ b/addon/modifiers/ref.js
@@ -1,5 +1,5 @@
 import { set, get } from '@ember/object';
-import { deprecate } from '@ember/application/deprecations';
+import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
 import { next } from '@ember/runloop';
 function hasValidTarget(target) {
@@ -10,27 +10,17 @@ function hasValidTarget(target) {
 function hasValidProperty(prop) {
   return typeof prop === 'string';
 }
-function getParams([maybeTarget, maybePropName]) {
-  if (typeof maybeTarget === 'function') {
+function getParams([target, propName]) {
+  if (typeof target === 'function') {
     return {
-      cb: maybeTarget
+      cb: target
     };
   }
-  const isPropNameString = typeof maybePropName === 'string';
-  if (!isPropNameString) {
-    deprecate(
-      'ember-ref-modifier: {{ref "propertyName" context}} has been changed to {{ref context "propertyName"}}. Please migrate to use this.',
-      false,
-      {
-        id: '@ember-ref-modifier--arguments-ordering-deprecation',
-        until: 'v1.0.0'
-      }
-    );
-  }
-  return {
-    propName: isPropNameString ? maybePropName : maybeTarget,
-    target: isPropNameString ? maybeTarget : maybePropName
-  };
+  assert(
+    `String ${target} used as context for ref modifier. Should be {{ref context "${target}"}}. You passed {{ref "${target}" context}}`,
+    typeof target !== 'string'
+  );
+  return { target, propName };
 }
 
 export default setModifierManager(

--- a/tests/dummy/app/components/ref-sample/template.hbs
+++ b/tests/dummy/app/components/ref-sample/template.hbs
@@ -1,4 +1,4 @@
-<div {{ref "divContainer" this}}></div>
+<div {{ref this "divContainer"}}></div>
 {{#-in-element this.divContainer}}
   Hello!
 {{/-in-element}}

--- a/tests/integration/modifiers/ref-test.js
+++ b/tests/integration/modifiers/ref-test.js
@@ -6,15 +6,6 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Modifier | ref', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it basically works: legacy', async function(assert) {
-    assert.expect(1);
-
-    await render(
-      hbs`<button data-foo="some-thing" {{ref "btn" this}}></button>`
-    );
-    assert.equal(this.btn.dataset.foo, 'some-thing');
-  });
-
   test('it basically works', async function(assert) {
     assert.expect(1);
 
@@ -22,23 +13,6 @@ module('Integration | Modifier | ref', function(hooks) {
       hbs`<button data-foo="some-thing" {{ref this "btn"}}></button>`
     );
     assert.equal(this.btn.dataset.foo, 'some-thing');
-  });
-
-  test('it is re-registered, when attrs changed: legacy', async function(assert) {
-    assert.expect(3);
-
-    await render(
-      hbs`<button data-foo="some-thing"  {{ref "btn" this}}></button>`
-    );
-
-    assert.equal(this.btn.dataset.foo, 'some-thing');
-
-    await render(
-      hbs`<button data-foo="some-thing"  {{ref "btns" this}}></button>`
-    );
-
-    assert.equal(this.btn, null);
-    assert.equal(this.btns.dataset.foo, 'some-thing');
   });
 
   test('it is re-registered, when attrs changed', async function(assert) {
@@ -58,40 +32,15 @@ module('Integration | Modifier | ref', function(hooks) {
     assert.equal(this.btns.dataset.foo, 'some-thing');
   });
 
-  test('it does nothing if ref key or target `null` or `undefined`: legacy', async function(assert) {
-    assert.expect(0);
-    await render(hbs`
-      <button data-foo="some-thing" {{ref "click" null}}></button>
-      <button data-foo="some-thing" {{ref "click" undefined}}></button>
-      <button data-foo="some-thing" {{ref  null "click"}}></button>
-      <button data-foo="some-thing" {{ref  undefined click}}></button>
-      <button data-foo="some-thing" {{ref  null null}}></button>
-      <button data-foo="some-thing" {{ref  undefined undefined}}></button>
-    `);
-  });
-
   test('it does nothing if ref key or target `null` or `undefined`', async function(assert) {
     assert.expect(0);
     await render(hbs`
       <button data-foo="some-thing" {{ref null "click"}}></button>
       <button data-foo="some-thing" {{ref undefined "click"}}></button>
-      <button data-foo="some-thing" {{ref "click" null}}></button>
       <button data-foo="some-thing" {{ref  click undefined}}></button>
       <button data-foo="some-thing" {{ref  null null}}></button>
       <button data-foo="some-thing" {{ref  undefined undefined}}></button>
     `);
-  });
-
-  test('it does not crash when updating to or from `null` / `undefined`: legacy', async function(assert) {
-    assert.expect(2);
-
-    this.set('ctx', null);
-    await render(hbs`<button {{ref "btn" this.ctx}}></button>`);
-
-    assert.equal(this.btn, undefined);
-    this.set('ctx', this);
-    await new Promise(resolve => setTimeout(resolve));
-    assert.equal(this.btn.tagName, 'BUTTON');
   });
 
   test('it does not crash when updating to or from `null` / `undefined`', async function(assert) {


### PR DESCRIPTION
Replaced deprecation with an assertion to ease transition for anyone who
missed the deprecation warning and is still using the old syntax.

Refs #197 