### PR TITLE
[breaking] Stop running in the next loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,28 @@ didInsertElement() {
 ```
 
 It will also re-register property, if any of the passed parameters change.
+
+## Updating a property twice in the same runloop
+
+When you have `computed` or `@tracked` properties that depend on the `{{ref}}` value you may see the error message
+
+```
+Error: Assertion Failed: You attempted to update `prop` on `Class`,but it had already been used previously in the same computation.
+```
+
+You will need to update your `{{ref}}` to use a callback and manually declare a new runloop to set the property in.
+
+```hbs
+{{ref this.setProp}}
+```
+
+```javascript
+import { next } from '@ember/runloop';
+@action
+setProp(element){
+  //set 'prop' in the next runloop so it does not cause a re-rendering calculation
+  run.next(()=> {
+    this.prop = element
+  });
+}
+```

--- a/addon/modifiers/ref.js
+++ b/addon/modifiers/ref.js
@@ -1,7 +1,7 @@
 import { set, get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
-import { next } from '@ember/runloop';
+import { run } from '@ember/runloop';
 function hasValidTarget(target) {
   return (
     typeof target === 'object' && target !== null && !Array.isArray(target)
@@ -69,10 +69,10 @@ export default setModifierManager(
       }
     },
     _setInContext(target, propName, value) {
-      next(this, '_setValues', target, propName, value);
+      run(this, '_setValues', target, propName, value);
     },
     _runInContext(cb, value) {
-      next(this, '_runCb', cb, value);
+      run(this, '_runCb', cb, value);
     },
     _runCb(cb, value) {
       cb(value);


### PR DESCRIPTION
This moves back to setting the property synchronously and adds
instructions for handling errors which are caused by this. In this case
causing the error seems better than creating difficult to see timing
bugs when Run.next() is invoked.

Lots of context and discussion and fixes #203.

Context for the original change (reverted here) in #195